### PR TITLE
Add bootstrap scripts and improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # SpeckleGrasshopper
+
 The Speckle Grasshopper Components (Sender &amp; Receiver)
+
+## Getting Started
+
+SpeckleGrasshopper has a number of dependent projects. You'll need to make sure that they're all cloned into the same directory.
+
+* [SpeckleGrasshopper](https://github.com/speckleworks/SpeckleGrasshopper) (that's _this_ repository)
+* [SpeckleAccountManager](https://github.com/speckleworks/SpeckleAccountManager)
+* [SpeckleCore](https://github.com/speckleworks/SpeckleCore)
+* [SpeckleRhinoConverter](https://github.com/speckleworks/SpeckleRhinoConverter)
+* [SpeckleUserDataUtils](https://github.com/speckleworks/SpeckleUserDataUtils)
+
+Next, run `script/boostrap.bat` to grab all the nuget dependencies required to compile SpeckleGrasshopper.
+
+Finally, build `SpeckleGrasshopper.sln`!

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# script/bootstrap: Resolve all dependencies that the application requires to
+#                   run.
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+echo "==> Checking for dependent projects..."
+echo
+
+[ -d ../SpeckleAccountManager ] || (echo "../SpeckleAccountManager missing" && exit 1)
+[ -d ../SpeckleCore ] || (echo "../SpeckleCore missing" && exit 1)
+[ -d ../SpeckleRhinoConverter ] || (echo "../SpeckleRhinoConverter missing" && exit 1)
+[ -d ../SpeckleUserDataUtils ] || (echo "../SpeckleUserDataUtils missing" && exit 1)
+
+echo "All there!"
+
+nuget="script/bin/nuget"
+
+echo
+echo "==> Installing SpeckleGrasshopper dependencies..."
+echo
+
+# $nuget restore packages.config -packagesdirectory packages
+$nuget restore SpeckleGrasshopper.sln
+
+echo
+echo "==> Installing SpeckleAccountManager dependencies..."
+echo
+
+$nuget restore ../SpeckleAccountManager/packages.config -packagesdirectory ../packages
+
+echo
+echo "==> Installing SpeckleCore dependencies..."
+echo
+
+$nuget restore ../SpeckleCore/SpeckleCore/packages.config -packagesdirectory ../SpeckleCore/SpeckleCore/packages
+
+echo
+echo "==> Installing SpeckleRhinoConverter dependencies..."
+echo
+
+$nuget restore ../SpeckleRhinoConverter/packages.config -packagesdirectory ../SpeckleRhinoConverter/packages
+
+echo
+echo "==> Installing SpeckleUserDataUtils dependencies..."
+echo
+
+$nuget restore ../SpeckleUserDataUtils/packages.config -packagesdirectory ../SpeckleUserDataUtils/packages
+
+echo
+echo "==> Ensure SpeckleSenderReceiver directory exists..."
+
+mkdir -p $HOME/AppData/Roaming/Grasshopper/Libraries/SpeckleSendReceive

--- a/script/bootstrap.bat
+++ b/script/bootstrap.bat
@@ -1,0 +1,5 @@
+:: Batch file wrapper around the bootstrap bash script
+
+cd /d %~dp0
+C:\Progra~1\Git\bin\bash bootstrap
+pause


### PR DESCRIPTION
@didimitrie Here's some stuff to make it easier for new people to get involved and contribute to Speckle. It may well become swiftly outdated if the projects get restructured, but it's a first step!

Adds a double-click-able .bat file that can be run to ensure that...

* Dependant projects exist where they're supposed to
* NuGet packages are downloaded for each individual project
* Ensures %AppData%\Grasshopper\Libraries\SpeckleSendReceive exists (for
  post-build copy commands)

The .bat file is just a thin wrapper around a bash file, so it assumes that you have Git for Windows installed (a fair assumption, I think! 😅).

Adds a "Getting Started" section to the README to explain how to get things compiling so you can start hacking!

nuget.exe (4.4.1) is vendored in script/bin, just in case it's not on the `%PATH%`.